### PR TITLE
feat: allow tls_server_name in the provider

### DIFF
--- a/util/client.go
+++ b/util/client.go
@@ -65,9 +65,10 @@ func (c *Client) lazyInit() error {
 		}
 
 		err := clientConfig.ConfigureTLS(&api.TLSConfig{
-			CACert:   d.Get("ca_cert_file").(string),
-			CAPath:   d.Get("ca_cert_dir").(string),
-			Insecure: d.Get("skip_tls_verify").(bool),
+			CACert:        d.Get("ca_cert_file").(string),
+			CAPath:        d.Get("ca_cert_dir").(string),
+			Insecure:      d.Get("skip_tls_verify").(bool),
+			TLSServerName: d.Get("tls_server_name").(string),
 
 			ClientCert: clientAuthCert,
 			ClientKey:  clientAuthKey,

--- a/vault/provider.go
+++ b/vault/provider.go
@@ -129,6 +129,12 @@ func Provider() *schema.Provider {
 				DefaultFunc: schema.EnvDefaultFunc("VAULT_SKIP_VERIFY", false),
 				Description: "Set this to true only if the target Vault server is an insecure development instance.",
 			},
+			"tls_server_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("VAULT_TLS_SERVER_NAME", false),
+				Description: "Name to use as the SNI host when connecting via TLS.",
+			},
 			"max_lease_ttl_seconds": {
 				Type:     schema.TypeInt,
 				Optional: true,

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -139,6 +139,9 @@ variables in order to keep credential information out of the configuration.
   that Terraform can be tricked into writing secrets to a server controlled
   by an intruder. May be set via the `VAULT_SKIP_VERIFY` environment variable.
 
+* `tls_server_name` - (Optional) Name to use as the SNI host when connecting
+  via TLS. May be set via the `VAULT_TLS_SERVER_NAME` environment variable.
+
 * `max_lease_ttl_seconds` - (Optional) Used as the duration for the
   intermediate Vault token Terraform issues itself, which in turn limits
   the duration of secret leases issued by Vault. Defaults to 20 minutes


### PR DESCRIPTION
so we can remove some skip verify in our tests.